### PR TITLE
fix(.vcmrc): removed required scope

### DIFF
--- a/.vcmrc
+++ b/.vcmrc
@@ -1,9 +1,9 @@
 {
   "types": ["feat", "fix", "docs", "style", "refactor", "perf", "test", "build", "ci", "chore", "revert"],
   "scope": {
-    "required": true,
+    "required": false,
     "allowed": ["*"],
-    "validate": true,
+    "validate": false,
     "multiple": true
   },
   "warnOnFail": false,


### PR DESCRIPTION
according to the http://conventionalcommits.org/, scope in a git commit message is optional:
`<type>[optional scope]: <description>`
but I had made it a required thing in .vcmrc settings. Fixed it.

@maniprataprana @muhzi4u @speedsters. Somebody needs to review it to merge it to staging branch. 